### PR TITLE
fix issue of missing APPDATA

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -27,7 +27,7 @@
 	}
 
 	const cacheExtra = process.platform === 'win32' ? 'npm-cache' : '.npm';
-	const cacheRoot = process.platform === 'win32' ? process.env.APPDATA : home;
+	const cacheRoot = process.platform === 'win32' && process.env.APPDATA || home;
 	const cache = path.resolve(cacheRoot, cacheExtra);
 
 	let defaults;


### PR DESCRIPTION
In production environment, some env variables including APPDATA may not be exposed to the application. Missing APPDATA caused an uncaught error: `TypeError: Path must be a string. Received undefined`.