### PR TITLE
Fall back to HOME when APPDATA isn't exposed on Windows (proper fix)

### DIFF
--- a/lib/make.js
+++ b/lib/make.js
@@ -34,7 +34,7 @@ const defaultsTemplate = body => `
 	}
 
 	const cacheExtra = process.platform === 'win32' ? 'npm-cache' : '.npm';
-	const cacheRoot = process.platform === 'win32' ? process.env.APPDATA : home;
+	const cacheRoot = process.platform === 'win32' && process.env.APPDATA || home;
 	const cache = path.resolve(cacheRoot, cacheExtra);
 
 	let defaults;


### PR DESCRIPTION
This is the same change as #7, but as mentioned in https://github.com/kevva/npm-conf/pull/7#pullrequestreview-84559407, the change should've been made in `lib/make.js`

This should fix #8 after it is published.